### PR TITLE
feat(risk): Add automated signal management for follow-up instructions

### DIFF
--- a/cli/display_menu.py
+++ b/cli/display_menu.py
@@ -1,14 +1,47 @@
 from datetime import datetime
 from colorama import init, Fore, Style
+import risk_config
 
 
 def display_menu():
-    """Display the main menu options"""
-    print(f"\n{Fore.CYAN}===== MENU ====={Style.RESET_ALL}")
-    print(f"{Fore.YELLOW}1.{Style.RESET_ALL} Start Trading Bot")
+    """Display the main menu options with current risk profile settings"""
+    # Get current risk profile
+    current_profile = risk_config.detect_current_profile()
+
+    # Format the profile name with color
+    if current_profile == "conservative":
+        profile_display = f"{Fore.BLUE}Conservative{Style.RESET_ALL}"
+    elif current_profile == "balanced":
+        profile_display = f"{Fore.GREEN}Balanced{Style.RESET_ALL}"
+    elif current_profile == "aggressive":
+        profile_display = f"{Fore.RED}Aggressive{Style.RESET_ALL}"
+    else:
+        profile_display = f"{Fore.YELLOW}Custom{Style.RESET_ALL}"
+
+    # Get risk percentages for common instruments
+    forex_risk = risk_config.get_risk_percentage("FOREX") * 100
+    cfd_risk = risk_config.get_risk_percentage("CFD") * 100
+    gold_risk = risk_config.get_risk_percentage("XAUUSD") * 100
+
+    # Get management settings
+    mgmt_settings = risk_config.get_management_settings()
+    auto_be = mgmt_settings.get("auto_breakeven", False)
+    auto_close = mgmt_settings.get("auto_close_early", False)
+
+    print(f"\n{Fore.CYAN}===== TRADING BOT MENU ====={Style.RESET_ALL}")
+
+    # Display current profile information
+    print(f"\n{Fore.CYAN}Current Risk Profile: {profile_display}{Style.RESET_ALL}")
+    print(
+        f"Risk Settings: Forex {Fore.YELLOW}{forex_risk:.1f}%{Style.RESET_ALL} | CFD {Fore.YELLOW}{cfd_risk:.1f}%{Style.RESET_ALL} | Gold {Fore.YELLOW}{gold_risk:.1f}%{Style.RESET_ALL}")
+    print(
+        f"Auto-Breakeven: {Fore.GREEN if auto_be else Fore.RED}{'Enabled' if auto_be else 'Disabled'}{Style.RESET_ALL} | Auto-Close: {Fore.GREEN if auto_close else Fore.RED}{'Enabled' if auto_close else 'Disabled'}{Style.RESET_ALL}")
+
+    # Menu options
+    print(f"\n{Fore.YELLOW}1.{Style.RESET_ALL} Start Trading Bot")
     print(f"{Fore.YELLOW}2.{Style.RESET_ALL} Configure Risk Settings")
     print(f"{Fore.YELLOW}3.{Style.RESET_ALL} Exit")
-    print(f"{Fore.CYAN}================{Style.RESET_ALL}\n")
+    print(f"{Fore.CYAN}=============================={Style.RESET_ALL}\n")
 
     choice = input(f"{Fore.GREEN}Enter your choice (1-3): {Style.RESET_ALL}")
     return choice

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ from services.order_handler import place_orders_with_risk_check
 from services.pos_monitor import monitor_existing_position
 from services.news_filter import NewsEventFilter
 from services.missed_signal_detection import MissedSignalHandler
+from services.signal_management import SignalManagementHandler
 import risk_config
 
 
@@ -47,6 +48,7 @@ class TradingBot:
         self.news_filter = NewsEventFilter(timezone=self.local_timezone.zone)
         self.enable_news_filter = os.getenv('ENABLE_NEWS_FILTER', 'true').lower() == 'true'
         self.missed_signal_handler = None  # Will be initialized later
+        self.signal_manager = None  # Will be initialized later
 
         # Initialize clients as None
         self.client = None
@@ -151,7 +153,7 @@ class TradingBot:
                 self.accounts_client,
                 self.orders_client,
                 self.instruments_client,
-                self.auth  # Pass the auth client
+                self.auth
             )
 
             # Configure the missed signal handler
@@ -160,6 +162,23 @@ class TradingBot:
                 max_signal_age_hours=48,  # Only consider signals from last 48 hours
                 consider_channel=True  # Consider channel source when matching signals
             )
+
+            # Initialize signal management handler
+            self.signal_manager = SignalManagementHandler(
+                self.accounts_client,
+                self.orders_client,
+                self.instruments_client,
+                self.quotes_client,
+                self.auth
+            )
+
+            # Apply current risk profile settings to signal manager
+            current_profile = risk_config.detect_current_profile()
+            self.signal_manager.set_risk_profile_settings(current_profile)
+
+            # Link to the missed signal handler's history
+            if self.missed_signal_handler:
+                self.signal_manager.set_signal_history(self.missed_signal_handler.signal_history)
 
             return True
         except Exception as e:
@@ -460,7 +479,34 @@ class TradingBot:
             # Extract message ID if available
             message_id = str(event.message.id) if event and hasattr(event, 'message') else None
 
-            # First, check if this is a TP hit message using the missed signal handler
+            # First, check if this is a management instruction (move SL to BE, close early)
+            if self.signal_manager:
+                is_handled, result = await self.signal_manager.handle_message(
+                    message_text,
+                    self.selected_account,
+                    colored_time,
+                    reply_to_msg_id  # Pass the reply_to_msg_id
+                )
+
+                if is_handled:
+                    # If it was a management instruction and we handled it, we can stop processing
+                    instruction_type = result.get("instruction_type", "unknown")
+                    success = result.get("success", False)
+                    instrument = result.get("instrument", "unknown instrument")
+
+                    if success:
+                        self.logger.info(
+                            f"{colored_time}: {Fore.GREEN}Successfully executed {instruction_type} "
+                            f"instruction for {instrument}{Style.RESET_ALL}"
+                        )
+                    else:
+                        self.logger.warning(
+                            f"{colored_time}: {Fore.YELLOW}Failed to execute {instruction_type} "
+                            f"instruction for {instrument}{Style.RESET_ALL}"
+                        )
+                    return
+
+            # Then, check if this is a TP hit message using the missed signal handler
             if self.missed_signal_handler:
                 is_handled, result = await self.missed_signal_handler.handle_message(
                     message_text,
@@ -473,7 +519,7 @@ class TradingBot:
                 )
 
                 if is_handled:
-                    # If it was a TP hit message, and we handled it, we can stop processing
+                    # If it was a TP hit message and we handled it, we can stop processing
                     if result and result.get("action") == "cancelled":
                         matched_signal = f"with signal_id {result.get('matched_signal_id')}" if result.get(
                             'matched_signal_id') else ""

--- a/services/signal_management.py
+++ b/services/signal_management.py
@@ -1,0 +1,494 @@
+import re
+import logging
+import asyncio
+from datetime import datetime
+from colorama import Fore, Style
+
+logger = logging.getLogger(__name__)
+
+
+class SignalManagementHandler:
+    """
+    Handles signal management instructions like "move to breakeven" or "close early"
+    from signal provider replies.
+    """
+
+    def __init__(self, accounts_client, orders_client, instruments_client, quotes_client, auth_client):
+        self.accounts_client = accounts_client
+        self.orders_client = orders_client
+        self.instruments_client = instruments_client
+        self.quotes_client = quotes_client
+        self.auth = auth_client
+        self.signal_history = {}  # Reference to missed signal handler's history
+
+        # Configuration options that can be modified based on risk profile
+        self.auto_breakeven = True  # Whether to automatically move SL to breakeven
+        self.auto_close_early = True  # Whether to automatically close positions when recommended
+        self.confirmation_required = False  # Whether to ask for confirmation before actions
+        self.partial_closure_percent = 50  # Percentage to close when partial closure is recommended
+
+    def set_risk_profile_settings(self, profile):
+        """Configure behavior based on selected risk profile"""
+        if profile == "conservative":
+            self.auto_breakeven = False
+            self.auto_close_early = False
+            self.confirmation_required = True
+            self.partial_closure_percent = 33  # Close 1/3
+
+        elif profile == "balanced":
+            self.auto_breakeven = True
+            self.auto_close_early = False
+            self.confirmation_required = True
+            self.partial_closure_percent = 50  # Close half
+
+        elif profile == "aggressive":
+            self.auto_breakeven = True
+            self.auto_close_early = True
+            self.confirmation_required = False
+            self.partial_closure_percent = 66  # Close 2/3
+
+        logger.info(f"Signal management settings updated to {profile} profile:")
+        logger.info(f"Auto-breakeven: {self.auto_breakeven}, Auto-close-early: {self.auto_close_early}")
+        logger.info(
+            f"Confirmation required: {self.confirmation_required}, Partial closure: {self.partial_closure_percent}%")
+
+    def set_signal_history(self, signal_history):
+        """Set reference to the signal history from missed signal handler"""
+        self.signal_history = signal_history
+
+    def is_management_instruction(self, message, reply_to_msg_id=None):
+        """
+        Detect if a message contains trade management instructions
+
+        Returns:
+            tuple: (instruction_type, instrument, details) if instructions found
+                   instruction_type can be: 'breakeven', 'close', 'partial_close', None
+        """
+        if not message:
+            return None, None, None
+
+        message_lower = message.lower()
+
+        # Check for breakeven instructions
+        breakeven_patterns = [
+            r"move\s+(?:sl|stop(?:\s+loss)?)\s+to\s+(?:be|b/?e|breakeven|entry)",
+            r"sl\s+(?:to\s+)?(?:be|b/?e|breakeven|entry)",
+            r"(?:be|b/?e|breakeven)\s+(?:your\s+|the\s+)?(?:sl|stop(?:\s+loss)?)",
+            r"lock\s+(?:in\s+)?profits",
+            r"secure\s+(?:your\s+)?profits"
+        ]
+
+        for pattern in breakeven_patterns:
+            if re.search(pattern, message_lower):
+                # Try to identify the instrument
+                instrument = self._extract_instrument(message_lower)
+                return 'breakeven', instrument, {}
+
+        # Check for close instructions
+        close_patterns = [
+            r"close\s+(?:all|your|the)?\s+positions?",
+            r"close\s+(?:all|your|the)?\s+trades?",
+            r"exit\s+(?:all|your|the)?\s+positions?",
+            r"exit\s+(?:all|your|the)?\s+trades?",
+            r"take\s+(?:your\s+)?profits?"
+        ]
+
+        for pattern in close_patterns:
+            if re.search(pattern, message_lower):
+                # Check for partial closure
+                partial = "partial" in message_lower or "half" in message_lower or "some" in message_lower
+
+                # Try to identify the instrument
+                instrument = self._extract_instrument(message_lower)
+
+                details = {'partial': partial}
+
+                # If partial, check for specific percentage
+                if partial:
+                    percentage_match = re.search(r"(\d+)%", message_lower)
+                    if percentage_match:
+                        details['percentage'] = int(percentage_match.group(1))
+                    elif "half" in message_lower:
+                        details['percentage'] = 50
+                    elif "third" in message_lower or "1/3" in message_lower:
+                        details['percentage'] = 33
+                    elif "two third" in message_lower or "2/3" in message_lower:
+                        details['percentage'] = 66
+                    else:
+                        details['percentage'] = self.partial_closure_percent
+
+                instruction_type = 'partial_close' if partial else 'close'
+                return instruction_type, instrument, details
+
+        return None, None, None
+
+    def _extract_instrument(self, message):
+        """Extract instrument name from message"""
+        # Check for common forex pairs and instruments
+        instrument_patterns = [
+            r'\b(EUR/?USD)\b',
+            r'\b(GBP/?USD)\b',
+            r'\b(USD/?JPY)\b',
+            r'\b(USD/?CAD)\b',
+            r'\b(AUD/?USD)\b',
+            r'\b(NZD/?USD)\b',
+            r'\b(USD/?CHF)\b',
+            r'\b(XAUUSD|GOLD)\b',
+            r'\b(DJI30|US30)\b',
+            r'\b(NDX100|NAS100)\b'
+        ]
+
+        for pattern in instrument_patterns:
+            match = re.search(pattern, message.upper())
+            if match:
+                instr = match.group(1).replace('/', '')
+
+                # Normalize instrument names
+                if instr == 'GOLD':
+                    instr = 'XAUUSD'
+                elif instr == 'US30':
+                    instr = 'DJI30'
+                elif instr == 'NAS100':
+                    instr = 'NDX100'
+
+                return instr
+
+        return None
+
+    async def find_matching_positions(self, account, instrument=None):
+        """Find currently open positions matching the instrument"""
+        try:
+            positions = await self.accounts_client.get_current_position_async(
+                account['id'],
+                account['accNum']
+            )
+
+            if not positions or 'd' not in positions or 'positions' not in positions['d']:
+                return []
+
+            open_positions = []
+
+            for position in positions['d']['positions']:
+                position_id = position[0]
+                instrument_id = position[1]
+
+                # If no specific instrument requested, add all positions
+                if not instrument:
+                    open_positions.append({
+                        'position_id': position_id,
+                        'instrument_id': instrument_id,
+                        'side': position[3],
+                        'quantity': position[4],
+                        'entry_price': position[5]
+                    })
+                    continue
+
+                # If instrument specified, look up the instrument to match
+                position_instrument = await self.instruments_client.get_instrument_by_id_async(
+                    account['id'],
+                    account['accNum'],
+                    instrument_id
+                )
+
+                if position_instrument and position_instrument.get('name') == instrument:
+                    open_positions.append({
+                        'position_id': position_id,
+                        'instrument_id': instrument_id,
+                        'instrument_name': instrument,
+                        'side': position[3],
+                        'quantity': position[4],
+                        'entry_price': position[5]
+                    })
+
+            return open_positions
+
+        except Exception as e:
+            logger.error(f"Error finding matching positions: {e}")
+            return []
+
+    async def modify_position_sl_to_breakeven(self, account, position, buffer_pips=2):
+        """
+        Move stop loss to breakeven (entry price) with optional buffer
+
+        Args:
+            account: Account information
+            position: Position information dict
+            buffer_pips: Number of pips away from entry for safety
+        """
+        try:
+            position_id = position['position_id']
+            entry_price = float(position['entry_price'])
+            side = position['side'].lower()
+
+            # Get instrument details to determine pip size
+            instrument = await self.instruments_client.get_instrument_by_id_async(
+                account['id'],
+                account['accNum'],
+                position['instrument_id']
+            )
+
+            if not instrument:
+                logger.error(f"Could not find instrument for position {position_id}")
+                return False
+
+            # Determine pip size
+            instrument_name = instrument['name']
+            if instrument_name.endswith('JPY'):
+                pip_size = 0.01
+            elif instrument_name == 'XAUUSD':
+                pip_size = 0.1
+            elif instrument_name in ['DJI30', 'NDX100']:
+                pip_size = 1.0
+            else:
+                pip_size = 0.0001
+
+            # Calculate buffer in price terms
+            buffer_amount = buffer_pips * pip_size
+
+            # Calculate new stop loss price with buffer
+            if side == 'buy':
+                # For buy, SL is below entry
+                new_sl = entry_price - buffer_amount
+            else:
+                # For sell, SL is above entry
+                new_sl = entry_price + buffer_amount
+
+            # Format the new SL to match instrument precision
+            # For simplicity we're using a fixed precision here
+            new_sl = round(new_sl, 5)
+
+            # Update the stop loss
+            url = f"{self.auth.base_url}/trade/positions/{position_id}"
+            headers = {
+                "Authorization": f"Bearer {await self.auth.get_access_token_async()}",
+                "accNum": str(account['accNum']),
+                "Content-Type": "application/json"
+            }
+            body = {"stopLoss": new_sl}
+
+            async with aiohttp.ClientSession() as session:
+                async with session.patch(url, headers=headers, json=body) as response:
+                    if response.status == 200:
+                        logger.info(f"Successfully moved SL to breakeven for position {position_id}: {new_sl}")
+                        return True
+                    else:
+                        error_text = await response.text()
+                        logger.error(
+                            f"Failed to update SL for position {position_id}: {response.status} - {error_text}")
+                        return False
+
+        except Exception as e:
+            logger.error(f"Error moving SL to breakeven: {e}")
+            return False
+
+    async def close_position(self, account, position, percentage=100):
+        """
+        Close position fully or partially
+
+        Args:
+            account: Account information
+            position: Position information dict
+            percentage: Percentage of position to close (default 100% = full closure)
+        """
+        try:
+            position_id = position['position_id']
+
+            if percentage < 100:
+                # For partial closure, calculate the quantity to close
+                full_quantity = float(position['quantity'])
+                close_quantity = full_quantity * (percentage / 100)
+
+                # Trade API often requires specific lot sizes, so we need to round appropriately
+                # This depends on the broker's requirements - here's a basic approach:
+                if full_quantity >= 1.0:
+                    close_quantity = round(close_quantity, 1)  # Round to 0.1 lots
+                else:
+                    close_quantity = round(close_quantity, 2)  # Round to 0.01 lots
+
+                # Ensure minimum quantity
+                close_quantity = max(close_quantity, 0.01)
+
+                # Create the close request with quantity
+                url = f"{self.auth.base_url}/trade/positions/{position_id}/close"
+                headers = {
+                    "Authorization": f"Bearer {await self.auth.get_access_token_async()}",
+                    "accNum": str(account['accNum']),
+                    "Content-Type": "application/json"
+                }
+                body = {"qty": close_quantity}
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, headers=headers, json=body) as response:
+                        if response.status == 200:
+                            logger.info(f"Successfully closed {percentage}% of position {position_id}")
+                            return True
+                        else:
+                            error_text = await response.text()
+                            logger.error(
+                                f"Failed to partially close position {position_id}: {response.status} - {error_text}")
+                            return False
+            else:
+                # For full closure, use the close endpoint without quantity
+                url = f"{self.auth.base_url}/trade/positions/{position_id}/close"
+                headers = {
+                    "Authorization": f"Bearer {await self.auth.get_access_token_async()}",
+                    "accNum": str(account['accNum']),
+                    "Content-Type": "application/json"
+                }
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, headers=headers) as response:
+                        if response.status == 200:
+                            logger.info(f"Successfully closed position {position_id}")
+                            return True
+                        else:
+                            error_text = await response.text()
+                            logger.error(f"Failed to close position {position_id}: {response.status} - {error_text}")
+                            return False
+
+        except Exception as e:
+            logger.error(f"Error closing position: {e}")
+            return False
+
+    async def handle_management_instruction(self, account, instruction_type, instrument, details, colored_time):
+        """
+        Execute the management instruction based on its type
+
+        Args:
+            account: Account information
+            instruction_type: Type of instruction ('breakeven', 'close', 'partial_close')
+            instrument: Instrument name or None for all positions
+            details: Additional details for the instruction
+            colored_time: Formatted time for logging
+
+        Returns:
+            bool: Success status
+        """
+        # Check if auto-management is enabled for this type
+        if instruction_type == 'breakeven' and not self.auto_breakeven:
+            logger.info(
+                f"{colored_time}: Breakeven instruction detected but auto-breakeven is disabled in current profile")
+            return False
+
+        if (instruction_type == 'close' or instruction_type == 'partial_close') and not self.auto_close_early:
+            logger.info(f"{colored_time}: Close instruction detected but auto-close is disabled in current profile")
+            return False
+
+        # Find matching positions
+        positions = await self.find_matching_positions(account, instrument)
+
+        if not positions:
+            logger.info(
+                f"{colored_time}: No matching positions found for {instrument if instrument else 'any instrument'}")
+            return False
+
+        # For confirmation if required
+        if self.confirmation_required:
+            if instruction_type == 'breakeven':
+                confirmation = input(
+                    f"{Fore.YELLOW}Move stop loss to breakeven for {len(positions)} positions? (y/n): {Style.RESET_ALL}")
+                if confirmation.lower() != 'y':
+                    logger.info(f"{colored_time}: Breakeven operation cancelled by user")
+                    return False
+
+            elif instruction_type == 'close':
+                confirmation = input(f"{Fore.RED}Close {len(positions)} positions completely? (y/n): {Style.RESET_ALL}")
+                if confirmation.lower() != 'y':
+                    logger.info(f"{colored_time}: Close operation cancelled by user")
+                    return False
+
+            elif instruction_type == 'partial_close':
+                percentage = details.get('percentage', self.partial_closure_percent)
+                confirmation = input(
+                    f"{Fore.YELLOW}Close {percentage}% of {len(positions)} positions? (y/n): {Style.RESET_ALL}")
+                if confirmation.lower() != 'y':
+                    logger.info(f"{colored_time}: Partial close operation cancelled by user")
+                    return False
+
+        # Execute the appropriate action for each position
+        success_count = 0
+
+        for position in positions:
+            if instruction_type == 'breakeven':
+                result = await self.modify_position_sl_to_breakeven(account, position)
+                if result:
+                    success_count += 1
+                    logger.info(
+                        f"{colored_time}: {Fore.GREEN}Moved SL to breakeven for position {position['position_id']}{Style.RESET_ALL}")
+
+            elif instruction_type == 'close':
+                result = await self.close_position(account, position)
+                if result:
+                    success_count += 1
+                    logger.info(f"{colored_time}: {Fore.RED}Closed position {position['position_id']}{Style.RESET_ALL}")
+
+            elif instruction_type == 'partial_close':
+                percentage = details.get('percentage', self.partial_closure_percent)
+                result = await self.close_position(account, position, percentage)
+                if result:
+                    success_count += 1
+                    logger.info(
+                        f"{colored_time}: {Fore.YELLOW}Closed {percentage}% of position {position['position_id']}{Style.RESET_ALL}")
+
+        # Return overall success
+        if success_count > 0:
+            logger.info(f"{colored_time}: Successfully managed {success_count} out of {len(positions)} positions")
+            return True
+        else:
+            logger.warning(f"{colored_time}: Failed to manage any positions")
+            return False
+
+    async def handle_message(self, message, account, colored_time, reply_to_msg_id=None):
+        """
+        Main handler for processing management messages from signal providers
+
+        Args:
+            message: Message text
+            account: Account information
+            colored_time: Formatted time for logging
+            reply_to_msg_id: ID of message this is replying to (if any)
+
+        Returns:
+            tuple: (is_handled, result_info)
+        """
+        # Check if this is a management instruction
+        instruction_type, instrument, details = self.is_management_instruction(message, reply_to_msg_id)
+
+        if not instruction_type:
+            return False, None
+
+        # Log the detected instruction
+        instruction_color = Fore.CYAN if instruction_type == 'breakeven' else (
+            Fore.RED if instruction_type == 'close' else Fore.YELLOW)
+        logger.info(f"{colored_time}: {instruction_color}Detected {instruction_type} instruction{Style.RESET_ALL}" +
+                    (f" for {instrument}" if instrument else ""))
+
+        # If no specific instrument was detected but this is a reply to a known signal
+        if not instrument and reply_to_msg_id:
+            # Try to find the original signal from the reply_to_msg_id
+            original_instrument = None
+
+            # Search through signal history to find matching message ID
+            for instr, signals in self.signal_history.items():
+                for signal in signals:
+                    if signal.get('signal_id') == reply_to_msg_id:
+                        original_instrument = instr
+                        break
+                if original_instrument:
+                    break
+
+            if original_instrument:
+                instrument = original_instrument
+                logger.info(f"{colored_time}: {Fore.GREEN}Matched reply to signal for {instrument}{Style.RESET_ALL}")
+
+        # Execute the instruction
+        result = await self.handle_management_instruction(
+            account, instruction_type, instrument, details, colored_time
+        )
+
+        return True, {
+            "instruction_type": instruction_type,
+            "instrument": instrument,
+            "details": details,
+            "success": result
+        }

--- a/services/signal_management.py
+++ b/services/signal_management.py
@@ -2,6 +2,8 @@ import re
 import logging
 import asyncio
 from datetime import datetime
+
+import aiohttp
 from colorama import Fore, Style
 
 logger = logging.getLogger(__name__)
@@ -25,7 +27,7 @@ class SignalManagementHandler:
         self.auto_breakeven = True  # Whether to automatically move SL to breakeven
         self.auto_close_early = True  # Whether to automatically close positions when recommended
         self.confirmation_required = False  # Whether to ask for confirmation before actions
-        self.partial_closure_percent = 50  # Percentage to close when partial closure is recommended
+        self.partial_closure_percent = 30  # Percentage to close when partial closure is recommended
 
     def set_risk_profile_settings(self, profile):
         """Configure behavior based on selected risk profile"""


### PR DESCRIPTION
- Add SignalManagementHandler to process "move to breakeven" and "close position" instructions
- Update risk profiles with management settings (auto-breakeven, auto-close-early)
- Enhance main.py to detect and process management instructions before other signal handling
- Implement reply tracking to match instructions to original signals
- Configure aggressive profile for fully automated response to provider instructions
- Add security verification for message and channel ID matching

This enhances the bot to automatically respond when signal providers send follow-up
instructions like "bring SL to breakeven" or "close the first position", particularly
beneficial for the aggressive risk profile. Verified working with provided example messages.