### PR TITLE
feat: add configurable daily drawdown percentage

### DIFF
--- a/cli/display_menu.py
+++ b/cli/display_menu.py
@@ -23,6 +23,9 @@ def display_menu():
     cfd_risk = risk_config.get_risk_percentage("CFD") * 100
     gold_risk = risk_config.get_risk_percentage("XAUUSD") * 100
 
+    # Get current drawdown percentage
+    drawdown_pct = risk_config.get_drawdown_percentage()
+
     # Get management settings
     mgmt_settings = risk_config.get_management_settings()
     auto_be = mgmt_settings.get("auto_breakeven", False)
@@ -33,7 +36,7 @@ def display_menu():
     # Display current profile information
     print(f"\n{Fore.CYAN}Current Risk Profile: {profile_display}{Style.RESET_ALL}")
     print(
-        f"Risk Settings: Forex {Fore.YELLOW}{forex_risk:.1f}%{Style.RESET_ALL} | CFD {Fore.YELLOW}{cfd_risk:.1f}%{Style.RESET_ALL} | Gold {Fore.YELLOW}{gold_risk:.1f}%{Style.RESET_ALL}")
+        f"Risk Settings: Forex {Fore.YELLOW}{forex_risk:.1f}%{Style.RESET_ALL} | CFD {Fore.YELLOW}{cfd_risk:.1f}%{Style.RESET_ALL} | Gold {Fore.YELLOW}{gold_risk:.1f}%{Style.RESET_ALL} | Daily Drawdown {Fore.MAGENTA}{drawdown_pct:.1f}%{Style.RESET_ALL}")
     print(
         f"Auto-Breakeven: {Fore.GREEN if auto_be else Fore.RED}{'Enabled' if auto_be else 'Disabled'}{Style.RESET_ALL} | Auto-Close: {Fore.GREEN if auto_close else Fore.RED}{'Enabled' if auto_close else 'Disabled'}{Style.RESET_ALL}")
 
@@ -55,6 +58,9 @@ def display_risk_menu():
     auto_close = mgmt_settings.get("auto_close_early", False)
     confirmation = mgmt_settings.get("confirmation_required", True)
 
+    # Get current drawdown percentage
+    drawdown_percentage = risk_config.get_drawdown_percentage()
+
     print(f"\n{Fore.CYAN}===== RISK MANAGEMENT CONFIGURATION ====={Style.RESET_ALL}")
     print(f"{Fore.YELLOW}1.{Style.RESET_ALL} View Current Risk Settings")
 
@@ -64,7 +70,7 @@ def display_risk_menu():
     print(f"{Fore.YELLOW}3.{Style.RESET_ALL} Apply {Fore.GREEN}Balanced{Style.RESET_ALL} Profile")
     print(f"{Fore.YELLOW}4.{Style.RESET_ALL} Apply {Fore.RED}Aggressive{Style.RESET_ALL} Profile")
 
-    # Management settings options (NEW)
+    # Management settings options
     print(f"\n{Fore.CYAN}-- Signal Management --{Style.RESET_ALL}")
     print(
         f"{Fore.YELLOW}5.{Style.RESET_ALL} Auto-Breakeven: [{Fore.GREEN if auto_be else Fore.RED}{'ON' if auto_be else 'OFF'}{Style.RESET_ALL}]")
@@ -78,12 +84,19 @@ def display_risk_menu():
     print(f"{Fore.YELLOW}8.{Style.RESET_ALL} Configure Forex Risk")
     print(f"{Fore.YELLOW}9.{Style.RESET_ALL} Configure CFD Risk")
     print(f"{Fore.YELLOW}10.{Style.RESET_ALL} Configure XAUUSD (Gold) Risk")
-    print(f"{Fore.YELLOW}11.{Style.RESET_ALL} Reset to Default Risk Settings")
-    print(f"{Fore.YELLOW}12.{Style.RESET_ALL} Return to Main Menu")
+
+    # NEW OPTION: Configure Daily Drawdown Percentage
+    print(
+        f"{Fore.YELLOW}11.{Style.RESET_ALL} Configure Daily Drawdown ({Fore.MAGENTA}{drawdown_percentage:.1f}%{Style.RESET_ALL})")
+
+    # Moved these options down by one
+    print(f"{Fore.YELLOW}12.{Style.RESET_ALL} Reset to Default Risk Settings")
+    print(f"{Fore.YELLOW}13.{Style.RESET_ALL} Return to Main Menu")
     print(f"{Fore.CYAN}========================================={Style.RESET_ALL}\n")
 
-    choice = input(f"{Fore.GREEN}Enter your choice (1-12): {Style.RESET_ALL}")
+    choice = input(f"{Fore.GREEN}Enter your choice (1-13): {Style.RESET_ALL}")
     return choice
+
 
 def get_risk_percentage_input(instrument_type, is_reduced=False):
     """
@@ -108,6 +121,40 @@ def get_risk_percentage_input(instrument_type, is_reduced=False):
                 return risk_value / 100  # Convert percentage to decimal
             else:
                 print(f"{Fore.RED}Risk must be between 0% and 10%{Style.RESET_ALL}")
+        except ValueError:
+            print(f"{Fore.RED}Please enter a valid number{Style.RESET_ALL}")
+
+        retry = input("Try again? (y/n): ").lower()
+        if retry != 'y':
+            return None
+
+
+def get_drawdown_percentage_input():
+    """
+    Get drawdown percentage input from user
+
+    Returns:
+        float: Drawdown percentage or None if invalid
+    """
+    # Get current drawdown percentage
+    current_percentage = risk_config.get_drawdown_percentage()
+
+    print(f"\n{Fore.CYAN}Daily Drawdown Configuration{Style.RESET_ALL}")
+    print(f"Current setting: {Fore.MAGENTA}{current_percentage:.1f}%{Style.RESET_ALL} of tier size")
+    print(f"This setting determines how much of your account you can lose in a day.")
+    print(f"PropFirm rules typically allow 4-5% maximum daily drawdown.")
+
+    while True:
+        try:
+            percentage_input = input(f"Enter new daily drawdown percentage (1.0-10.0): ")
+            percentage_value = float(percentage_input)
+
+            # Validate range
+            if 1.0 <= percentage_value <= 10.0:
+                return percentage_value
+            else:
+                print(f"{Fore.RED}Drawdown percentage must be between 1% and 10%{Style.RESET_ALL}")
+
         except ValueError:
             print(f"{Fore.RED}Please enter a valid number{Style.RESET_ALL}")
 

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from services.drawdown_manager import (
     schedule_daily_reset_async,
     max_drawdown_balance
 )
+from cli.display_menu import display_menu, display_risk_menu, get_risk_percentage_input, get_drawdown_percentage_input
 from services.order_handler import place_orders_with_risk_check
 from services.pos_monitor import monitor_existing_position
 from services.news_filter import NewsEventFilter
@@ -790,15 +791,13 @@ async def handle_risk_configuration():
                 risk_config.display_current_risk_settings()
                 input("\nPress Enter to continue...")
 
-        # NEW OPTIONS FOR MANAGEMENT SETTINGS
+        # Management settings options
         elif risk_choice == '5':
             # Toggle Auto-Breakeven
             new_value = risk_config.toggle_management_setting("auto_breakeven")
             status = "ENABLED" if new_value else "DISABLED"
             color = Fore.GREEN if new_value else Fore.RED
             print(f"{color}Auto-Breakeven is now {status}{Style.RESET_ALL}")
-
-            # Note about profile impact
             print(f"{Fore.YELLOW}Note: This creates a custom profile based on your current settings.{Style.RESET_ALL}")
             input("\nPress Enter to continue...")
 
@@ -808,8 +807,6 @@ async def handle_risk_configuration():
             status = "ENABLED" if new_value else "DISABLED"
             color = Fore.GREEN if new_value else Fore.RED
             print(f"{color}Auto-Close Early is now {status}{Style.RESET_ALL}")
-
-            # Note about profile impact
             print(f"{Fore.YELLOW}Note: This creates a custom profile based on your current settings.{Style.RESET_ALL}")
             input("\nPress Enter to continue...")
 
@@ -829,7 +826,6 @@ async def handle_risk_configuration():
                 print(
                     f"{Fore.RED}The bot will execute all signal provider instructions automatically.{Style.RESET_ALL}")
 
-            # Note about profile impact
             print(f"{Fore.YELLOW}Note: This creates a custom profile based on your current settings.{Style.RESET_ALL}")
             input("\nPress Enter to continue...")
 
@@ -882,6 +878,21 @@ async def handle_risk_configuration():
             print(f"{Fore.GREEN}XAUUSD risk settings updated.{Style.RESET_ALL}")
 
         elif risk_choice == '11':
+            # NEW OPTION: Configure Daily Drawdown percentage
+            print(f"\n{Fore.CYAN}Configuring Daily Drawdown Percentage{Style.RESET_ALL}")
+
+            # Get new drawdown percentage
+            new_drawdown = get_drawdown_percentage_input()
+            if new_drawdown:
+                risk_config.update_drawdown_percentage(new_drawdown)
+                print(f"{Fore.GREEN}Daily drawdown percentage updated to {new_drawdown:.1f}%.{Style.RESET_ALL}")
+                print(
+                    f"{Fore.YELLOW}Note: This creates a custom profile based on your current settings.{Style.RESET_ALL}")
+                print(f"{Fore.YELLOW}The new setting will apply after the next daily reset.{Style.RESET_ALL}")
+
+            input("\nPress Enter to continue...")
+
+        elif risk_choice == '12':
             # Reset to defaults
             confirmation = input(
                 f"{Fore.YELLOW}Are you sure you want to reset to default (balanced) risk settings? (y/n): {Style.RESET_ALL}").lower()
@@ -889,7 +900,7 @@ async def handle_risk_configuration():
                 risk_config.apply_risk_profile("balanced")
                 print(f"{Fore.GREEN}Risk settings reset to defaults (balanced profile).{Style.RESET_ALL}")
 
-        elif risk_choice == '12':
+        elif risk_choice == '13':
             # Return to main menu
             return
 


### PR DESCRIPTION
- Add drawdown settings to risk profiles (3% conservative, 4% balanced, 5% aggressive)
- Create functions to get and update drawdown percentage in risk_config
- Modify drawdown_manager to use configurable percentage instead of hardcoded 4%
- Add UI option to adjust drawdown percentage in risk management menu
- Update main menu to display current drawdown percentage
- Fix missing schedule_daily_reset function in drawdown_manager

This change allows users to adjust their daily drawdown limit to match specific prop firm requirements instead of using a fixed 4% value.