### PR TITLE
fix: ensure TP commands cancel all pending orders

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import pytz
 import platform
 import signal
 import sys
-import getpass
+
 from colorama import init, Fore, Style
 from dotenv import load_dotenv
 from telethon import TelegramClient, events

--- a/order_cache.py
+++ b/order_cache.py
@@ -73,9 +73,16 @@ class OrderCache:
             logger.error(f"Error saving order cache: {e}")
             return False
 
-    def store_orders(self, message_id, order_ids, take_profits, instrument=None):
+    def store_orders(self, message_id, order_ids, take_profits, instrument=None, entry_price=None):
         """
-        Store order IDs with message ID and take profits in global memory first
+        Store order IDs with message ID, take profits, and entry price in global memory first
+
+        Args:
+            message_id: Telegram message ID (will be converted to string)
+            order_ids: List of order IDs
+            take_profits: List of take profit levels
+            instrument: Optional instrument name
+            entry_price: Entry price for breakeven functionality
         """
         global GLOBAL_ORDER_CACHE
 
@@ -97,6 +104,7 @@ class OrderCache:
             'orders': str_order_ids,
             'take_profits': take_profits,
             'instrument': instrument,
+            'entry_price': entry_price,  # Store entry price
             'timestamp': datetime.now().isoformat()
         }
 


### PR DESCRIPTION
- Modified signal_management.py to cancel all pending orders when a TP command is received
- Implemented parallel processing for faster order cancellation
- Fixed issue where TP commands would only cancel one order instead of all orders
- Added better error handling and logging for order cancellation
- Ensured TP commands only affect pending orders and never close active positions
- Improved cache management to properly remove orders and messages